### PR TITLE
opentelemetry-exporter-otlp 1.38.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-exporter-otlp" %}
-{% set version = "1.37.0" %}
+{% set version = "1.38.0" %}
 
 
 package:
@@ -8,12 +8,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: f85b1929dd0d750751cc9159376fb05aa88bb7a08b6cdbf84edb0054d93e9f26
+  sha256: 2f55acdd475e4136117eff20fbf1b9488b1b0b665ab64407516e1ac06f9c3f9d
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -38,12 +38,12 @@ test:
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp
-  summary: OpenTelemetry Collector Exporters
-  description: |
-    This library is provided as a convenience to install all supported OpenTelemetry Collector Exporters. 
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
+  summary: OpenTelemetry Collector Exporters
+  description: |
+    This library is provided as a convenience to install all supported OpenTelemetry Collector Exporters. 
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp
   doc_url: https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/opentelemetry-exporter-otlp/README.rst
 


### PR DESCRIPTION
opentelemetry-exporter-otlp 1.38.0 

**Destination channel:** Defaults

### Links

- [PKG-10844]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.38.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-exporter-otlp-feedstock
- pypi:           https://pypi.org/project/opentelemetry-exporter-otlp/1.38.0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-exporter-otlp/1.38.0

### Explanation of changes:

- new version number


[PKG-10844]: https://anaconda.atlassian.net/browse/PKG-10844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ