### PR TITLE
opentelemetry-exporter-otlp 1.40.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-exporter-otlp" %}
-{% set version = "1.38.0" %}
+{% set version = "1.40.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 2f55acdd475e4136117eff20fbf1b9488b1b0b665ab64407516e1ac06f9c3f9d
+  sha256: 7caa0870b95e2fcb59d64e16e2b639ecffb07771b6cd0000b5d12e5e4fef765a
 
 build:
   number: 0


### PR DESCRIPTION
Bumps version from 1.38.0 → 1.40.0.

## Changes
- Version: 1.38.0 → 1.40.0
- SHA256: updated
- Run deps (`opentelemetry-exporter-otlp-proto-grpc` and `-proto-http`) pin via `{{ version }}` and update automatically

Both Tier 5 deps are already released on pkgs/main:
- `opentelemetry-exporter-otlp-proto-http 1.40.0` (PR #7, released)
- `opentelemetry-exporter-otlp-proto-grpc 1.40.0` (PR #7, released)

No test changes needed — test section already uses `pip check` + import only (no pytest).