### PR TITLE
opentelemetry-exporter-otlp 1.12.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: ecc9f0c22b98b0ca860e80736fb2c5225032814de3da6f531eeaf365643f5650
 
 build:
-  number: 0
+  number: 4
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   # No opentelemetry-exporter-otlp-proto-http support for py>312
   skip: true  # [py<36 or py>312]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,41 +3,58 @@
 
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry-exporter-otlp-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: ecc9f0c22b98b0ca860e80736fb2c5225032814de3da6f531eeaf365643f5650
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  # No opentelemetry-exporter-otlp-proto-http support for py>312
+  skip: true  # [py<36 or py>312]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - wheel
+    - setuptools <81
   run:
-    - python >=3.6
-    - opentelemetry-exporter-otlp-proto-grpc ==1.12.0
-    - opentelemetry-exporter-otlp-proto-http ==1.12.0
+    - python
+    - opentelemetry-exporter-otlp-proto-grpc =={{ version }}
+    - opentelemetry-exporter-otlp-proto-http =={{ version }}
+    - setuptools <81
 
 test:
+  source_files:
+    - tests
   imports:
     - opentelemetry
     - opentelemetry.exporter.otlp
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp
   summary: OpenTelemetry Collector Exporters
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  description: |
+    This library is provided as a convenience to install
+    all supported OpenTelemetry Collector Exporters. 
+    Currently it installs:
+      - opentelemetry-exporter-otlp-proto-grpc
+      - opentelemetry-exporter-otlp-proto-http
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp
+  doc_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
opentelemetry-exporter-otlp 1.12.0

**Destination channel:** Snowflake

### Links

- [PKG-14902](https://anaconda.atlassian.net/browse/PKG-14902) 
- [Upstream repository](https://inspector.pypi.io/project/opentelemetry-exporter-otlp/1.12.0/)

### Explanation of changes:

- rebuild


[PKG-14902]: https://anaconda.atlassian.net/browse/PKG-14902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ